### PR TITLE
new ca with properly used token uri

### DIFF
--- a/components/core/MintButton.tsx
+++ b/components/core/MintButton.tsx
@@ -17,7 +17,7 @@ declare let window: {
 };
 
 const MintButton = () => {
-  const contractAddress = '0x58e61C0ec26dCb0E3dCE5821563Ab5275d8782E9';
+  const contractAddress = '0x31568b2A19e7483e741D4D5CD750fa3F1ceE1ddc';
   const [fetching, setFetching] = useState<boolean>(false);
   const [txHash, setTxHash] = useState<string | null>(null);
   const [error, setError] = useState<string | undefined>(undefined);


### PR DESCRIPTION
-properly used the token uri in deployment of the smart contract so the nft can be visible  even on metamask /web3 wallets

former:
![image](https://github.com/user-attachments/assets/c61da3d4-3dfb-410e-b194-ff4e28f03a3f)

current change:
![image](https://github.com/user-attachments/assets/602c7406-f688-48c0-b8d6-a43bf5dd169d)
